### PR TITLE
Fix version file URL property

### DIFF
--- a/GameData/WildBlueIndustries/SLOTH/Sloth.version
+++ b/GameData/WildBlueIndustries/SLOTH/Sloth.version
@@ -1,6 +1,6 @@
 {
     "NAME":"Kerbal Actuators: S.L.O.T.H.",
-    "URL":"https://raw.githubusercontent.com/Angel-125/SLOTH/master/SLOTH/GameData/WildBlueIndustries/SLOTH/MoreServos.version",
+    "URL":"https://raw.githubusercontent.com/Angel-125/SLOTH/master/GameData/WildBlueIndustries/SLOTH/Sloth.version",
     "DOWNLOAD":"https://github.com/Angel-125/SLOTH/releases",
     "GITHUB":
     {


### PR DESCRIPTION
Hi @Angel-125!

The version file URL property is a 404:

https://raw.githubusercontent.com/Angel-125/SLOTH/master/SLOTH/GameData/WildBlueIndustries/SLOTH/MoreServos.version

There's an extra instance of the mod name after the branch name, and the filename is from a different mod. Now it's fixed:

https://raw.githubusercontent.com/Angel-125/SLOTH/master/GameData/WildBlueIndustries/SLOTH/Sloth.version

Noticed while working on KSP-CKAN/NetKAN#8906.